### PR TITLE
[63388] MODIFY: Upgrade Microsoft.Identity.Web to 4.14.2, align Azure…

### DIFF
--- a/Ofqual.Recognition.Citizen.API.Core/Ofqual.Recognition.Citizen.API.Core.csproj
+++ b/Ofqual.Recognition.Citizen.API.Core/Ofqual.Recognition.Citizen.API.Core.csproj
@@ -10,10 +10,9 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.3.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.9.3" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/Ofqual.Recognition.Citizen.API.Infrastructure/Ofqual.Recognition.Citizen.API.Infrastructure.csproj
+++ b/Ofqual.Recognition.Citizen.API.Infrastructure/Ofqual.Recognition.Citizen.API.Infrastructure.csproj
@@ -10,10 +10,9 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="GovukNotify" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.9.3" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Polly" Version="8.6.1" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Ofqual.Recognition.Citizen.API.Tests/Ofqual.Recognition.Citizen.API.Tests.csproj
+++ b/Ofqual.Recognition.Citizen.API.Tests/Ofqual.Recognition.Citizen.API.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Microsoft.NET.Test.SDK" Version="17.13.0" />
+    <PackageReference Include="SSH.NET" Version="2026.0.0" />
     <PackageReference Include="Testcontainers" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/Ofqual.Recognition.Citizen.API.Tests/Ofqual.Recognition.Citizen.API.Tests.csproj
+++ b/Ofqual.Recognition.Citizen.API.Tests/Ofqual.Recognition.Citizen.API.Tests.csproj
@@ -12,9 +12,8 @@
     <PackageReference Include="Docker.DotNet" Version="3.125.15" />
     <PackageReference Include="Docker.DotNet.BasicAuth" Version="3.125.15" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.9.3" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Microsoft.NET.Test.SDK" Version="17.13.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
     <PackageReference Include="Testcontainers" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">

--- a/Ofqual.Recognition.Citizen.API/Ofqual.Recognition.Citizen.API.csproj
+++ b/Ofqual.Recognition.Citizen.API/Ofqual.Recognition.Citizen.API.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
+    <PackageReference Include="Azure.Identity" Version="1.17.2" />
     <PackageReference Include="CorrelationId" Version="3.0.1" />
     <PackageReference Include="GovukNotify" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.17" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Identity.Web" Version="3.9.3" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
@@ -20,7 +20,6 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Http.LogzIo" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ variables:
   dotnetVersion: '8.0'
 
 stages:
-# Static Analysis stage: This stage runs static code analysis using SonarQube and audits dependencies for vulnerabilities.
+# Static Analysis stage: This stage runs static code analysis using Snyk and audits dependencies for vulnerabilities.
 - stage: StaticAnalysis
   displayName: 'Run Static Analysis'
   condition: always()
@@ -50,14 +50,7 @@ stages:
           command: "build"
           projects: "**/*.csproj"
           arguments: "--no-restore"
-      # Step 4: Install and authenticate Snyk
-      - script: |
-          npm install -g snyk
-          snyk config set endpoint=$(SNYK_ENDPOINT)
-          snyk auth $(SNYK_TOKEN)
-          set +e
-        displayName: 'Snyk Install & Auth'
-      # Step 5: Scan code
+      # Step 4: Scan code
       - task: SnykSecurityScan@1
         displayName: 'Snyk scanning code'
         inputs:
@@ -65,7 +58,7 @@ stages:
           testType: 'code'
           codeSeverityThreshold: 'high'
           failOnIssues: true
-      # Step 6: Scan app
+      # Step 5: Scan app
       - task: SnykSecurityScan@1
         displayName: 'Snyk scanning app'
         inputs:
@@ -74,7 +67,7 @@ stages:
           severityThreshold: 'high'
           failOnIssues: true
           additionalArguments: '--all-projects --exclude=Ofqual.Recognition.Citizen.Api.Tests'
-      # Step 7: Scan docker image     
+      # Step 6: Scan docker image     
       - task: Docker@2
         displayName: Build Docker Image
         inputs:
@@ -92,7 +85,6 @@ stages:
           dockerfilePath: './Dockerfile'
           severityThreshold: 'high'
           failOnIssues: true
-
 
     # Audit job: This job audits dependencies for vulnerabilities.
     - job: Audit

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,17 +64,16 @@ stages:
           serviceConnectionEndpoint: 'snyk-integration-eu'
           testType: 'code'
           codeSeverityThreshold: 'high'
-          failOnIssues: false
+          failOnIssues: true
       # Step 6: Scan app
       - task: SnykSecurityScan@1
         displayName: 'Snyk scanning app'
         inputs:
           serviceConnectionEndpoint: 'snyk-integration-eu'
           testType: 'app'
-          monitorWhen: 'always'
           severityThreshold: 'high'
-          failOnIssues: false
-          additionalArguments: '--all-projects'
+          failOnIssues: true
+          additionalArguments: '--all-projects --exclude=Ofqual.Recognition.Citizen.Api.Tests'
       # Step 7: Scan docker image     
       - task: Docker@2
         displayName: Build Docker Image
@@ -91,9 +90,8 @@ stages:
           testType: 'container'
           dockerImageName: '$(SNYK_DOCKER_REPOS):latest'
           dockerfilePath: './Dockerfile'
-          monitorWhen: 'always'
           severityThreshold: 'high'
-          failOnIssues: false
+          failOnIssues: true
 
 
     # Audit job: This job audits dependencies for vulnerabilities.


### PR DESCRIPTION
….Identity to 1.17.2, and remove obsolete System.Security.Cryptography.Xml package reference



- Upgraded Microsoft.Identity.Web from 3.9.3 to 4.14.2
- Aligned Azure.Identity from 1.17.0 to 1.17.2
- Removed the obsolete direct System.Security.Cryptography.Xml package reference from Ofqual.Recognition.Citizen.API.csproj



A Snyk vulnerability was still being detected via a transitive dependency on System.Security.Cryptography.Xml
Upgrading Microsoft.Identity.Web resolves the vulnerable transitive dependency
Azure.Identity was updated to satisfy the new transitive dependency requirement

Microsoft.Identity.Web 4.14.2 now depends on Azure.Identity >= 1.17.2
The project previously referenced Azure.Identity 1.17.0
That created a package downgrade conflict, so Azure.Identity was raised to 1.17.2
In short: the direct Azure.Identity version was updated to match the newer transitive dependency requirement from Microsoft.Identity.Web